### PR TITLE
fix: Adding CA option to HttpsOptions type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -388,9 +388,10 @@ export class GraphQLServer {
 
     return new Promise((resolve, reject) => {
       const combinedServer = server
-      const port = typeof this.options.port !== "number" 
-        ? parseInt(this.options.port) 
-        : this.options.port
+      const port =
+        typeof this.options.port !== 'number'
+          ? parseInt(this.options.port, 10)
+          : this.options.port
       combinedServer.listen(port, this.options.host, () => {
         callbackFunc({
           ...this.options,

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,6 +71,7 @@ export interface ApolloServerOptions {
 export interface HttpsOptions {
   cert: string | Buffer
   key: string | Buffer
+  ca: string | array | Buffer
 }
 
 export interface Options extends ApolloServerOptions {

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,7 +71,7 @@ export interface ApolloServerOptions {
 export interface HttpsOptions {
   cert: string | Buffer
   key: string | Buffer
-  ca: string | array | Buffer
+  ca: string | Buffer
 }
 
 export interface Options extends ApolloServerOptions {

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,7 +71,7 @@ export interface ApolloServerOptions {
 export interface HttpsOptions {
   cert: string | Buffer
   key: string | Buffer
-  ca: string | Buffer
+  ca?: string | Buffer | Array<string | Buffer>
 }
 
 export interface Options extends ApolloServerOptions {


### PR DESCRIPTION
This flag allows to set the CA flag (`An authority certificate or array of authority certificates to check the remote host against.`)

Docs: https://node.readthedocs.io/en/latest/api/https/#httpsrequestoptions-callback

This adds the ability to enable SSL on the server where the SSL certificate requires intermediate certificate(s) (https://support.ssl.com/Knowledgebase/Article/View/11/0/what-is-an-intermediate-certificate).